### PR TITLE
data destruction prevention using KubeArmor Policy

### DIFF
--- a/MITRE/Impact/Data Destruction/datadestruction.yaml
+++ b/MITRE/Impact/Data Destruction/datadestruction.yaml
@@ -1,0 +1,30 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-data-destruction
+  namespace: <namespace>
+spec:
+  severity: 8
+  message: "data destruction alert"
+  selector:
+    matchLabels:
+      <key>: <value>
+  process:
+   matchPaths:
+   - path: /bin/rm
+     onDirectory: 
+     - path: /bin/
+     - path: /usr/bin/
+     - path: /usr/sbin/
+   matchPaths:
+   - path: /bin/rmdir
+     onDirectory: 
+     - path: /bin/
+     - path: /usr/bin/
+     - path: /usr/sbin/
+   matchPaths:
+   - path: /usr/bin/dd
+     onDirectory:
+     - path: *
+  action:
+    Block


### PR DESCRIPTION
The KubeArmor Policy denied the use of `rm` `rmdir` commands on system folders like `/bin/` `/usr/bin/` `/usr/sbin/` and also denies the use of `dd` command to destroy the data on any folder

- The dd command can be used to overwrite the data content. 
- `dd of=#{file_to_overwrite} if=#{overwrite_source}`