### PR TITLE
[Rule] Priviledge Escalation - S-bit

### DIFF
--- a/MITRE/Privilege Escalation/Abuse Elevation Control Mechanism/Setuid and Setgid/rule.yaml
+++ b/MITRE/Privilege Escalation/Abuse Elevation Control Mechanism/Setuid and Setgid/rule.yaml
@@ -17,5 +17,5 @@ spec:
     - proc.args: +s
     - proc.args: 4777       
   action:
-    Enforce
+    BlockwithAudit
   severity: 5

--- a/MITRE/Privilege Escalation/Abuse Elevation Control Mechanism/Setuid and Setgid/rule.yaml
+++ b/MITRE/Privilege Escalation/Abuse Elevation Control Mechanism/Setuid and Setgid/rule.yaml
@@ -1,0 +1,21 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-privilege-escalation
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  syscall:
+    matchPaths: 
+    - path: /sys/stat.h
+    matchName:
+    - name: syscall
+    - parameter: chmod , fchmod
+    condition:
+    - proc.name: chmod 
+    - proc.args: +s
+    - proc.args: 4777       
+  action:
+    Enforce
+  severity: 5


### PR DESCRIPTION
S bit can be escalated using chmod or fchmod command. When these two commands are initiated, the syscall file stat.h is executed. 