### PR TITLE
Audit File Manipulation

### DIFF
--- a/MITRE/Defense Evasion/File and Directory Permissions Modification/Linux and Mac File and Directory Permissions Modification/Audit File Manipulation
+++ b/MITRE/Defense Evasion/File and Directory Permissions Modification/Linux and Mac File and Directory Permissions Modification/Audit File Manipulation
@@ -1,0 +1,17 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-defense-evasion-file-manipulation
+spec:
+  selectorLabels:
+     nodeSelector:
+           hostname: xyz 
+  syscall:
+    matchPaths: 
+    - path: /usr/bin
+    matchName:
+    - name: syscall
+    - parameter: chown, chmod     
+  action:
+    Audit
+  severity: 5


### PR DESCRIPTION
This policy will be invoked when a user attempts a file manipulation using commands: chmod (Modify permission) chown (Change owner group).
In general, in Kubernetes Environment, there is no reason why these commands would be used. 
An audit will be initiated immediately after a syscall for chmod and chown is made.