### PR TITLE
Defense Evasion: Monitor PAM Configuration

### DIFF
--- a/MITRE/Defense Evasion/Modify Authentication Process/Pluggable Authentication Modules/Monitor PAM Configuration
+++ b/MITRE/Defense Evasion/Modify Authentication Process/Pluggable Authentication Modules/Monitor PAM Configuration
@@ -1,0 +1,19 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-defense-evasion-PAM-audit
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  process: 
+        matchPaths: 
+        - path: /etc/pam.d/
+        - path: /usr/lib/x86_64-linux-gnu/security/pam_unix.so
+        - path: /snap/core18/1988/lib/x86_64-linux-gnu/security/pam_unix.so
+        - path: /snap/core18/2066/lib/x86_64-linux-gnu/security/pam_unix.so
+        - path: /etc/passwd
+        - path: /etc/shadow
+  action:
+    Audit
+  severity: 3


### PR DESCRIPTION
Adversaries may modify pluggable authentication modules (PAM) to access user credentials or enable otherwise unwarranted access to accounts. PAM is a modular system of configuration files, libraries, and executable files which guide authentication for many services. The most common authentication module is pam_unix.so, which retrieves, sets, and verifies account authentication information in /etc/passwd and /etc/shadow.

So, this policy audits any changes to these paths: /etc/pam.d/, pam_unix.so, /etc/passwd, /etc/shadow