### PR TITLE
Defense Evasion: Impair Defense [SELinux Audit]

### DIFF
--- a/MITRE/Defense Evasion/Impair Defenses/Disable or Modify Tools/SELinux-Audit.yaml
+++ b/MITRE/Defense Evasion/Impair Defenses/Disable or Modify Tools/SELinux-Audit.yaml
@@ -1,0 +1,23 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-defense-evasion-SELinux-Audit
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  process: 
+        matchPaths: 
+        - path: /etc/selinux/*  #The following two commands will audit any actions on these two paths
+        - path: /etc/sysconfig/selinux
+        matchPaths: 
+        - path: /etc/selinux/*
+          onDirectory: 
+          - path: ~/.setenforce   #This commmand will conduct an audit if setenforce is executed in these two file paths.
+        matchPaths: 
+        - path: /etc/sysconfig/selinux
+          onDirectory: 
+          - path: ~/.setenforce 
+  action:
+    Audit
+  severity: 3


### PR DESCRIPTION
Adversaries may disable security tools to avoid possible detection of their tools and activities.

This policy will audit any event which could lead to disabling of LSMs: For SELinux, audit any edits to the following filesystem paths:
/etc/selinux/*
/etc/sysconfig/selinux

Also audit process execution of "setenforce"