### PR TITLE
Defense Evasion: Impair Defenses [Bash History Audit]

### DIFF
--- a/MITRE/Defense Evasion/Impair Defenses/Impair Command History Logging/Bash_history.yaml
+++ b/MITRE/Defense Evasion/Impair Defenses/Impair Command History Logging/Bash_history.yaml
@@ -1,0 +1,17 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-defense-evasion-Bash_History
+spec:
+  runAsNonRoot: true
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  process: 
+          matchPaths: 
+        - path: <any path>
+          onDirectory: 
+          - path: ~/.bash_history
+  action:
+    Audit
+  severity: 3


### PR DESCRIPTION
Audit file changes to ./bash_history from non-bash parent process. This will filter the processes which try to directly open the bash_history file.

This policy will be applied when any non-root user tries to access the Bash History.