### PR TITLE
[Rule] Privilege Escalation - Sudo and Sudo Caching

### DIFF
--- a/MITRE/Privilege Escalation/Abuse Elevation Control Mechanism/Sudo and Sudo Caching/rule.yaml
+++ b/MITRE/Privilege Escalation/Abuse Elevation Control Mechanism/Sudo and Sudo Caching/rule.yaml
@@ -1,0 +1,18 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-sudo-caching
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  process:
+        matchPaths: 
+        - path: /var/db/sudo
+        - path: /etc/sudoers
+        condition : >
+          tty_tickets = False
+          timestamp_timeout = False   
+  action:
+    BlockwithAudit
+  severity: 5


### PR DESCRIPTION
tty_tickets and timestamp_timeout should always be enabled/True if not block the process