### PR TITLE
Defense Evasion: Clear Linux System Logs

### DIFF
--- a/MITRE/Defense Evasion/Indicator Removal on Host/ T1070002_linux_sys_log.yaml
+++ b/MITRE/Defense Evasion/Indicator Removal on Host/ T1070002_linux_sys_log.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-defense-evasion-system-log
+spec:
+  severity: 5
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  file:
+    matchDirectories:
+    - dir: /var/log/
+      recursive: true
+      readOnly: true
+  action:
+    Audit


### PR DESCRIPTION
Adversaries may clear system logs to hide evidence of an intrusion.
To prevent from this made /var/log/ dir as read-only.

