### PR TITLE
Defense Evasion: Timestomp

### DIFF
--- a/MITRE/Defense Evasion/Indicator Removal on Host/T1070006_timestomp.yaml
+++ b/MITRE/Defense Evasion/Indicator Removal on Host/T1070006_timestomp.yaml
@@ -1,0 +1,21 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-defence-evasion-timestomp
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  file:
+    matchPaths: 
+    - path: /usr/bin/touch
+    condition:
+    - proc.name: touch 
+    - proc.args: -a
+    - proc.args: -m 
+    - proc.args: -t
+    - proc.args: -r 
+    - proc.args: -d      
+  action:
+    Block
+  severity: 5


### PR DESCRIPTION
Adversaries may clear system logs to hide evidence of an intrusion.
To prevent from this made /var/log/ dir as read-only.

