### PR TITLE
[Rule] Privilege Escalation - Ptrace Syscall

### DIFF
--- a/MITRE/Privilege Escalation/Process Injection/Ptrace System Calls/rule.yaml
+++ b/MITRE/Privilege Escalation/Process Injection/Ptrace System Calls/rule.yaml
@@ -1,0 +1,38 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-ptrace-syscall
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  process:
+        matchPaths: 
+        - path: /proc/sys/kernel/yama/ptrace_scope 
+        - path: /etc/sysctl.d/10-ptrace.conf      
+  tasks:
+    - name: Get running processes list from remote host that uses the above mentioned path
+      ignore_errors: yes
+      shell: "ps -few | grep '/proc/sys/kernel/yama/ptrace_scope|/etc/sysctl.d/10-ptrace.conf' | awk '{print $2}'"
+      register: running_processes
+
+    - name: Kill running processes
+      ignore_errors: yes
+      shell: "kill {{ item }}"
+      with_items: "{{ running_processes.stdout_lines }}"
+
+    - wait_for:
+        path: "/proc/{{ item }}/status"
+        state: absent
+      with_items: "{{ running_processes.stdout_lines }}"
+      ignore_errors: yes
+      register: ptrace_process
+ 
+    - name: Force kill stuck processes
+      ignore_errors: yes
+      shell: "kill -9 {{ item }}"
+      with_items: "{{ ptrace_process.results | select('failed') | map(attribute='item') | list }}"
+
+  action:
+    EnforcewithAudit
+  severity: 4


### PR DESCRIPTION
/proc values are stored in RAM and aren't persistent. But it read its initial values from a file. One can permanently change the value of /proc/sys/kernel/yama/ptrace_scope to 0 by editing the file /etc/sysctl.d/10-ptrace.conf and change the value of  kernel.yama.ptrace_scope = 1 to 0