### PR TITLE
Defense-Evasion:PortKnocking

### DIFF
--- a/MITRE/Defense Evasion/TrafficSignaling/knockport.yaml
+++ b/MITRE/Defense Evasion/TrafficSignaling/knockport.yaml
@@ -1,0 +1,23 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-defence-evasion-port-knocking
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  file:
+    matchPaths: 
+    - path: /usr/sbin/iptables
+    - path: /etc/knockd.conf
+    condition:
+    - proc.name: iptables 
+    - proc.args: -a
+    - proc.args: -m 
+    - proc.args: -s 
+    - proc.args: -p
+    - proc.args: -dport
+    - proc.args: -j      
+  action:
+    Block
+  severity: 4

--- a/MITRE/Defense Evasion/TrafficSignaling/knockport.yaml
+++ b/MITRE/Defense Evasion/TrafficSignaling/knockport.yaml
@@ -19,5 +19,5 @@ spec:
     - proc.args: -dport
     - proc.args: -j      
   action:
-    Block
+    Audit
   severity: 4


### PR DESCRIPTION
Adversaries may use port knocking to hide open ports used for persistence or command and control. 