### PR TITLE
persistence_boot_or_logon_initialization_scripts_rc_scripts

### DIFF
--- a/kubearmor_persistence_blis_rc.yaml
+++ b/kubearmor_persistence_blis_rc.yaml
@@ -1,0 +1,20 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-persistence-blis-RC
+spec:
+  selectorLabels:
+    nodeSelector:
+      hostname: xyz
+  process:
+    matchPaths:
+      - path: /etc/rc.local
+      - path: /lib/systemd/system/rc-local.service
+      - path: /lib/systemd/system/rc-local.service.d
+      - path: /lib/systemd/system/rc.service
+      - path: /usr/lib/systemd/system/rc-local.service
+      - path: /usr/lib/systemd/system/rc-local.service.d
+      - path: /usr/lib/systemd/system/rc.service
+  action:
+    Block
+  severity: 5

--- a/kubearmor_persistence_blis_rc.yaml
+++ b/kubearmor_persistence_blis_rc.yaml
@@ -15,6 +15,5 @@ spec:
       - path: /usr/lib/systemd/system/rc-local.service
       - path: /usr/lib/systemd/system/rc-local.service.d
       - path: /usr/lib/systemd/system/rc.service
-  action:
-    Block
+  action: Block
   severity: 5


### PR DESCRIPTION
Adversaries may establish persistence by modifying RC scripts which are executed during a Unix-like system’s startup.

Adversaries can establish persistence by adding a malicious binary path or shell commands to rc.local, rc.common, and other RC scripts specific to the Unix-like distribution. Upon reboot, the system executes the script's contents as root, resulting in persistence.