### PR TITLE
Persistence:createaccount-localaccount

### DIFF
--- a/MITRE/Persistence/Create Account/Local Account/Persistence-createaccount.yaml
+++ b/MITRE/Persistence/Create Account/Local Account/Persistence-createaccount.yaml
@@ -2,14 +2,18 @@ apiVersion: security.accuknox.com/v1
 kind: KubeArmorPolicy
 metadata:
   name: mitre-tactic-persistence-createaccount-localaccount
+  namespace: multiubuntu
 spec:
-  selectorLabels:
-      nodeSelector:
-          hostname: xyz
-  process: 
-        matchPaths: 
-        - path: /usr/sbin/useradd
-        - path: /usr/sbin/adduser.conf
-  action:
-    Audit
-  severity: 2
+  severity: 4
+  selector:
+    matchLabels:
+      container: ubuntu-1
+  process:
+    matchPaths:
+      - path: /usr/sbin/useradd
+  file:
+    matchPaths:
+      - path: /etc/passwd
+      - path: /etc/shadow
+  action: 
+     Block

--- a/MITRE/Persistence/Create Account/Local Account/Persistence-createaccount.yaml
+++ b/MITRE/Persistence/Create Account/Local Account/Persistence-createaccount.yaml
@@ -1,0 +1,14 @@
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-persistence-createaccount-localaccount
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  process: 
+        matchPaths: 
+        - path: /usr/sbin/useradd
+        - path: /usr/sbin/adduser.conf
+  action:
+    Audit
+  severity: 2

--- a/MITRE/Persistence/Create Account/Local Account/Persistence-createaccount.yaml
+++ b/MITRE/Persistence/Create Account/Local Account/Persistence-createaccount.yaml
@@ -1,3 +1,4 @@
+apiVersion: security.accuknox.com/v1
 kind: KubeArmorPolicy
 metadata:
   name: mitre-tactic-persistence-createaccount-localaccount


### PR DESCRIPTION
Adversaries may create an account to maintain access to victim systems.