### PR TITLE
Defense-evasion:RootCertificate

### DIFF
--- a/MITRE/Defense Evasion/Subvert Trust Controls/Install Root Certificate/root_certificate.yaml
+++ b/MITRE/Defense Evasion/Subvert Trust Controls/Install Root Certificate/root_certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-defense-evasion-root-certificate
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  file:
+    matchDirectories:
+    - dir: /usr/local/share/ca-certificates/*
+      recursive: true
+      readOnly: true
+    - path: /etc/ca-certificates.conf
+  action:
+    Audit 
+  severity: 4


### PR DESCRIPTION
Adversaries may install a root certificate on a compromised system to avoid warnings when connecting to adversary controlled web servers. 
Root Certificates:Certificates are commonly used for establishing secure TLS/SSL communications within a web browser. When a user attempts to browse a website that presents a certificate that is not trusted an error message will be displayed to warn the user of the security risk. Depending on the security settings, the browser may not allow the user to establish a connection to the website.
Installation of a root certificate on a compromised system would give an adversary a way to degrade the security of that system. Adversaries have used this technique to avoid security warnings prompting users when compromised systems connect over HTTPS to adversary controlled web servers that spoof legitimate websites in order to collect login credentials.
