### PR TITLE
Presistence: Kernel Modules and Extensions

### DIFF
--- a/MITRE/Persistence/Boot or Logon Autostart Execution/Kernel Modules and Extensions/T1547_006_LKMs_exec.yaml
+++ b/MITRE/Persistence/Boot or Logon Autostart Execution/Kernel Modules and Extensions/T1547_006_LKMs_exec.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-presistence-kernel-modules
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz 
+  process:
+    matchPaths: 
+    - path: /usr/sbin/insmod
+    - path: /usr/sbin/modprobe    
+  action:
+    Audit
+  severity: 5


### PR DESCRIPTION
Adversaries may modify the kernel to automatically execute programs on system boot.
Loadable Kernel Modules (LKMs) are pieces of code that can be loaded and unloaded into the kernel upon demand.

