### PR TITLE
Persistence:DynamicLinkerHijacking[LD-PRELOAD]

### DIFF
--- a/MITRE/Persistence/Hijack Execution Flow/LD_PRELOAD/dynamiclinkerhijacking.yaml
+++ b/MITRE/Persistence/Hijack Execution Flow/LD_PRELOAD/dynamiclinkerhijacking.yaml
@@ -1,0 +1,18 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-persistence-dynamic-linker-hijacking
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz
+  file:
+    matchPaths: 
+    - path: /proc/<pid>/environ
+    - path: /etc/ld.so.preload
+    condition:
+    - process: LD_PRELOAD
+    
+  action:
+    Audit
+  severity: 4


### PR DESCRIPTION
Adversaries may execute their own malicious payloads by hijacking environment variables the dynamic linker uses to load shared libraries. 
During the execution preparation phase of a program, the dynamic linker loads specified absolute paths of shared libraries from environment variables and files, such as LD_PRELOAD .
These variables are often used by developers to debug binaries without needing to recompile, deconflict mapped symbols, and implement custom functions without changing the original library., 
Adversaries may set LD_PRELOAD to point to malicious libraries that match the name of legitimate libraries which are requested by a victim program, causing the operating system to load the adversary's malicious code upon execution of the victim program.