### PR TITLE
Credential-Access:Password-Dumping

### DIFF
--- a/MITRE/Credential Access/OS Credential Dumping/_etc_passwd and _etc_shadow/pswd.yaml
+++ b/MITRE/Credential Access/OS Credential Dumping/_etc_passwd and _etc_shadow/pswd.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: mitre-tactic-credential-access-password-dumping
+spec:
+  selectorLabels:
+      nodeSelector:
+          hostname: xyz 
+  process:
+    matchPaths: 
+    - path: /etc/passwd
+    - path: /etc/shadow
+  action:
+    Audit
+  severity: 4
+


### PR DESCRIPTION
Adversaries may attempt to dump the contents of /etc/passwd and /etc/shadow to enable offline password cracking. 