### PR TITLE
persistence_create_or_modify_system_process_systemd_service

### DIFF
--- a/create_or_modify_system_process_systemd_service.yaml
+++ b/create_or_modify_system_process_systemd_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: create-or-modify-system-process-systemd-service
+spec:
+  selectorLables:
+    nodeSelector:
+      hostname: xyz
+  process:
+    matchPaths:
+      - path: /etc/systemd/system
+      - path: /usr/lib/systemd/system/
+      - path: /home//.config/systemd/user/
+  action: Audit
+  severity: 4


### PR DESCRIPTION
Adversaries may create or modify systemd services to repeatedly execute malicious payloads as part of persistence. The systemd service manager is commonly used for managing background daemon processes (also known as services) and other system resources. Systemd is the default initialization (init) system on many Linux distributions starting with Debian 8, Ubuntu 15.04, CentOS 7, RHEL 7, Fedora 15, and replaces legacy init systems including SysVinit and Upstart while remaining backwards compatible with the aforementioned init systems.