### PR TITLE
credential_access_os_credential_dumping_proc_filesystem 

### DIFF
--- a/CA_OS_credential_dumping_proc_filesystem.yaml
+++ b/CA_OS_credential_dumping_proc_filesystem.yaml
@@ -7,8 +7,8 @@ spec:
     nodeSelector:
       hostname: xyz
   process:
-    matchPaths:
-      - path: /proc/
-      - path: /proc/*/maps
+    matchDirectories:
+      - dir: /proc/
+        recursive: true
   action: AllowwithAudit
   severity: 2

--- a/CA_OS_credential_dumping_proc_filesystem.yaml
+++ b/CA_OS_credential_dumping_proc_filesystem.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: credential-access-os-credential-dumping-proc-filesystem 
+spec:
+  selectorLables:
+    nodeSelector:
+      hostname: xyz
+  process:
+    matchPaths:
+      - path: /proc/
+      - path: /proc/*/maps
+  action: AllowwithAudit
+  severity: 2

--- a/create_or_modify_system_process_systemd_service.yaml
+++ b/create_or_modify_system_process_systemd_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: create-or-modify-system-process-systemd-service
+spec:
+  selectorLables:
+    nodeSelector:
+      hostname: xyz
+  process:
+    matchPaths:
+      - path: /etc/systemd/system
+      - path: /usr/lib/systemd/system/
+      - path: /home//.config/systemd/user/
+  action: Audit
+  severity: 4


### PR DESCRIPTION
Adversaries may gather credentials from information stored in the Proc filesystem or /proc. The Proc filesystem on Linux contains a great deal of information regarding the state of the running operating system. Processes running with root privileges can use this facility to scrape live memory of other running programs. If any of these programs store passwords in clear text or password hashes in memory, these values can then be harvested for either usage or brute force attacks, respectively.