### PR TITLE
persistence_boot_or_logon_IS_rc_script

### DIFF
--- a/MITRE/Persistence/Boot or Logon Initialization Scripts/RC Scripts/persistence_boot_or_logon_initialization_scripts_rc_scripts.yaml
+++ b/MITRE/Persistence/Boot or Logon Initialization Scripts/RC Scripts/persistence_boot_or_logon_initialization_scripts_rc_scripts.yaml
@@ -1,0 +1,34 @@
+apiVersion: security.accuknox.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: persistence-blis-rc-scripts
+  namespace: testns
+spec:
+  severity: 5
+  selector:
+    matchLabels:
+      container: ubuntu-1
+  process:
+    matchPaths:
+      - path: /etc/rc.local
+      - path: /lib/systemd/system/rc-local.service
+      - path: /lib/systemd/system/rc.service
+      - path: /usr/lib/systemd/system/rc-local.service
+      - path: /usr/lib/systemd/system/rc.service
+    matchDirectories:
+      - dir: /lib/systemd/system/rc-local.service.d
+        recursive: true
+      - dir: /usr/lib/systemd/system/rc-local.service.d
+  file:
+    matchPaths:
+      - path: /etc/rc.local
+      - path: /lib/systemd/system/rc-local.service
+      - path: /lib/systemd/system/rc.service
+      - path: /usr/lib/systemd/system/rc-local.service
+      - path: /usr/lib/systemd/system/rc.service
+    matchDirectories:
+      - dir: /lib/systemd/system/rc-local.service.d
+        recursive: true
+      - dir: /usr/lib/systemd/system/rc-local.service.d 
+  action:
+    Block


### PR DESCRIPTION
Adversaries may establish persistence by modifying RC scripts which are executed during a Unix-like system’s startup.

Adversaries can establish persistence by adding a malicious binary path or shell commands to rc.local, rc.common, and other RC scripts specific to the Unix-like distribution. Upon reboot, the system executes the script's contents as root, resulting in persistence.