### PR TITLE
credential_access_os_credential_dumping_proc_filesystem

### DIFF
--- a/MITRE/Credential Access/OS Credential Dumping/Proc Filesystem/credential_access_os_credential_dumping_proc_filesystem.yaml
+++ b/MITRE/Credential Access/OS Credential Dumping/Proc Filesystem/credential_access_os_credential_dumping_proc_filesystem.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: credential-access-os-credential-dumping-proc-filesystem
+  namespace: testns  #use your namespace name here
+spec:
+  severity: 3
+  selector:
+    matchLabels:
+      container: ubuntu-1  #use your labels name here
+  file:
+    matchDirectories:
+      - dir: /proc/
+        recursive: true
+        readOnly: true
+  action: Audit


### PR DESCRIPTION
Adversaries may gather credentials from information stored in the Proc filesystem or /proc. The Proc filesystem on Linux contains a great deal of information regarding the state of the running operating system. Processes running with root privileges can use this facility to scrape live memory of other running programs. If any of these programs store passwords in clear text or password hashes in memory, these values can then be harvested for either usage or brute force attacks, respectively.