### PR TITLE
persistence_create_or_modify_system_process_systemd_service

### DIFF
--- a/MITRE/Persistence/Create or Modify System Process/Systemd Service/persistence_create_or_modify_system_process_systemd_service.yaml
+++ b/MITRE/Persistence/Create or Modify System Process/Systemd Service/persistence_create_or_modify_system_process_systemd_service.yaml
@@ -1,0 +1,30 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: create-or-modify-system-process-systemd-service
+  namespace: testns  #use your namespace name here
+spec:
+  severity: 5
+  selector:
+    matchLabels:
+      container: ubuntu-1  #use your labels name here
+  process:
+    matchDirectories:
+      - dir: /etc/systemd/system/
+        recursive: true
+      - dir: /usr/lib/systemd/
+        recursive: true
+      - dir: /lib/systemd/system/
+        recursive: true
+  file:
+    matchDirectories:
+      - dir: /etc/systemd/system/
+        recursive: true
+        readOnly: false
+      - dir: /usr/lib/systemd/
+        recursive: true
+        readOnly: false
+      - dir: /lib/systemd/system
+        recursive: true
+        readOnly: false
+  action: Audit


### PR DESCRIPTION
Adversaries may create or modify systemd services to repeatedly execute malicious payloads as part of persistence. The systemd service manager is commonly used for managing background daemon processes (also known as services) and other system resources. Systemd is the default initialization (init) system on many Linux distributions starting with Debian 8, Ubuntu 15.04, CentOS 7, RHEL 7, Fedora 15, and replaces legacy init systems including SysVinit and Upstart while remaining backwards compatible with the aforementioned init systems.