### PR TITLE
discovery_account_discovery_local_account

### DIFF
--- a/MITRE/Discovery/Account Discovery/Local Account/discovery_account_discovery_local_account.yaml
+++ b/MITRE/Discovery/Account Discovery/Local Account/discovery_account_discovery_local_account.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorPolicy
+metadata:
+  name: discovery-account-discovery-local-account
+  namespace: testns  #use your namespace name here
+spec:
+  severity: 3
+  selector:
+    matchLabels:
+      container: ubuntu-1  #use your labels name here
+  process:
+    matchPaths:
+      - path: /usr/bin/id
+      - path: /usr/bin/groups
+      - path: /usr/bin/net
+    action: Audit


### PR DESCRIPTION
Adversaries may attempt to get a listing of local system accounts. This information can help adversaries determine which local accounts exist on a system to aid in follow-on behavior.