### PR TITLE
Sock mount disallow 

### DIFF
--- a/best-practices/disallow-sock-mount/README.md
+++ b/best-practices/disallow-sock-mount/README.md
@@ -1,0 +1,27 @@
+# Rules
+Container daemon socket bind mounts allows access to the container engine on the node. This access can be used for privilege escalation and to manage containers outside of Kubernetes, and hence should not be allowed.
+
+## Rule1
+The  '/var/run/docker.sock' should be audited 
+
+## Rule2
+The  '/var/run/containerd.sock' should be audited 
+
+## Rule3
+The  '/var/run/crio.sock' should be audited 
+
+### Severity
+<p style='color:orange'><b>Medium</b></p>
+
+
+### Configuration
+NA
+
+### Applicability
+Host, Container
+
+### Policy Engine
+KubeArmor
+
+### Action
+Audit, Enforce

--- a/best-practices/disallow-sock-mount/validate-containerd-sock-mount.yml
+++ b/best-practices/disallow-sock-mount/validate-containerd-sock-mount.yml
@@ -1,0 +1,15 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: validate-containerd-sock-mount
+spec:
+  severity: 5
+  message: "Use of the Containerd Unix socket is not allowed."
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: ubuntu20
+  file:
+    matchPaths:
+    - path: /var/run/containerd.sock
+  action:
+    Audit

--- a/best-practices/disallow-sock-mount/validate-crio-sock-mount.yml
+++ b/best-practices/disallow-sock-mount/validate-crio-sock-mount.yml
@@ -1,0 +1,15 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: validate-crio-sock-mount
+spec:
+  severity: 5
+  message: "Use of the CRI-O Unix socket is not allowed.."
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: ubuntu20
+  file:
+    matchPaths:
+    - path: /var/run/crio.sock
+  action:
+    Audit

--- a/best-practices/disallow-sock-mount/validate-docker-sock-mount.yml
+++ b/best-practices/disallow-sock-mount/validate-docker-sock-mount.yml
@@ -1,0 +1,15 @@
+apiVersion: security.kubearmor.com/v1
+kind: KubeArmorHostPolicy
+metadata:
+  name: validate-docker-sock-mount
+spec:
+  severity: 5
+  message: "Use of the Docker Unix socket is not allowed."
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: ubuntu20
+  file:
+    matchPaths:
+    - path: /var/run/docker.sock
+  action:
+    Audit


### PR DESCRIPTION
Container daemon socket bind mounts allows access to the container engine on the node. This access can be used for privilege escalation and to manage containers outside of Kubernetes, and hence should not be allowed.